### PR TITLE
Add a strategy to report and allocate device

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,14 +31,23 @@ import (
 	"volcano.sh/k8s-device-plugin/pkg/plugin/nvidia"
 )
 
+var deviceFactor *uint
+
+func init() {
+	deviceFactor = flag.Uint("factor", 1, "gpu virtual device's division factor")
+}
+
 func getAllPlugins() []plugin.DevicePlugin {
 	return []plugin.DevicePlugin{
-		nvidia.NewNvidiaDevicePlugin(),
+		nvidia.NewNvidiaDevicePlugin(*deviceFactor),
 	}
 }
 
 func main() {
 	flag.Parse()
+	if *deviceFactor <= 0 {
+		*deviceFactor = 1
+	}
 
 	log.Println("Starting file watcher.")
 	watcher, err := filewatcher.NewFileWatcher(pluginapi.DevicePluginPath)

--- a/pkg/plugin/nvidia/const.go
+++ b/pkg/plugin/nvidia/const.go
@@ -35,4 +35,6 @@ const (
 	TotalGPUResource = "VOLCANO_GPU_TOTAL"
 	// NVIDIA visible devices
 	VisibleDevice = "NVIDIA_VISIBLE_DEVICES"
+	// GPU factor
+	GPUFactor = "VOLCANO_GPU_FACTOR"
 )

--- a/pkg/plugin/nvidia/server.go
+++ b/pkg/plugin/nvidia/server.go
@@ -49,12 +49,13 @@ type NvidiaDevicePlugin struct {
 	// Virtual devices
 	virtualDevices []*pluginapi.Device
 	devicesByIndex map[uint]string
+	factor         uint
 
 	kubeInteractor *KubeInteractor
 }
 
 // NewNvidiaDevicePlugin returns an initialized NvidiaDevicePlugin
-func NewNvidiaDevicePlugin() *NvidiaDevicePlugin {
+func NewNvidiaDevicePlugin(factor uint) *NvidiaDevicePlugin {
 	log.Println("Loading NVML")
 	if err := nvml.Init(); err != nil {
 		log.Printf("Failed to initialize NVML: %s.", err)
@@ -82,6 +83,7 @@ func NewNvidiaDevicePlugin() *NvidiaDevicePlugin {
 		stop:            nil,
 		virtualDevices:  nil,
 		devicesByIndex:  nil,
+		factor:          factor,
 	}
 }
 
@@ -91,7 +93,7 @@ func (m *NvidiaDevicePlugin) initialize() {
 	m.health = make(chan *Device)
 	m.stop = make(chan struct{})
 
-	m.virtualDevices, m.devicesByIndex = GetDevices()
+	m.virtualDevices, m.devicesByIndex = GetDevices(m.factor)
 }
 
 func (m *NvidiaDevicePlugin) cleanup() {
@@ -328,6 +330,7 @@ Allocate:
 				VisibleDevice:        fmt.Sprintf("%d", id),
 				AllocatedGPUResource: fmt.Sprintf("%d", reqGPU),
 				TotalGPUResource:     fmt.Sprintf("%d", gpuMemory),
+				GPUFactor:            fmt.Sprintf("%d", m.factor),
 			},
 		}
 		responses.ContainerResponses = append(responses.ContainerResponses, &response)

--- a/pkg/plugin/nvidia/utils.go
+++ b/pkg/plugin/nvidia/utils.go
@@ -89,7 +89,7 @@ func GetDevices() ([]*pluginapi.Device, map[uint]string) {
 		if GetGPUMemory() == uint(0) {
 			SetGPUMemory(uint(*d.Memory))
 		}
-		for j := uint(0); j < GetGPUMemory(); j++ {
+		for j := uint(0); j < GetGPUMemory()/factor; j++ {
 			fakeID := GenerateVirtualDeviceID(id, j)
 			virtualDevs = append(virtualDevs, &pluginapi.Device{
 				ID:     fakeID,

--- a/volcano-device-plugin.yml
+++ b/volcano-device-plugin.yml
@@ -84,6 +84,7 @@ spec:
       containers:
       - image: volcanosh/volcano-device-plugin:latest
         name: volcano-device-plugin
+        args: ["-factor", "1"]
         env:
           - name: NODE_NAME
             valueFrom:


### PR DESCRIPTION
Kubelet reports "grpc: received message larger than max". The size of data returned from ListAndWatch is biggeer than 4M.
Anyway it needs a strategic way to report device information.
This patch adds a division factor(divisor),  by which  device amount divides.

Signed-off-by: longguang.yue <yuelg@chinaunicom.cn>