### PR TITLE
Raise grpc max message size from 4M to 16M

### DIFF
--- a/pkg/plugin/nvidia/const.go
+++ b/pkg/plugin/nvidia/const.go
@@ -35,4 +35,11 @@ const (
 	TotalGPUResource = "VOLCANO_GPU_TOTAL"
 	// NVIDIA visible devices
 	VisibleDevice = "NVIDIA_VISIBLE_DEVICES"
+
+	// DefaultMaxRecvMsgSize defines the default maximum message size for
+	// receiving protobufs passed over the GRPC API.
+	DefaultMaxRecvMsgSize = 16 << 20
+	// DefaultMaxSendMsgSize defines the default maximum message size for
+	// sending protobufs passed over the GRPC API.
+	DefaultMaxSendMsgSize = 16 << 20
 )

--- a/pkg/plugin/nvidia/server.go
+++ b/pkg/plugin/nvidia/server.go
@@ -354,6 +354,8 @@ func (m *NvidiaDevicePlugin) dial(unixSocketPath string, timeout time.Duration) 
 		grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
 			return net.DialTimeout("unix", addr, timeout)
 		}),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(DefaultMaxRecvMsgSize)),
+		grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(DefaultMaxSendMsgSize)),
 	)
 
 	if err != nil {


### PR DESCRIPTION
Raise grpc max message size from 4M to 16M

Signed-off-by: longguang.yue <yuelg@chinaunicom.cn>