### PR TITLE
Fix #17 Warning UnexpectedAdmissionError

### DIFF
--- a/pkg/plugin/nvidia/nvidia.go
+++ b/pkg/plugin/nvidia/nvidia.go
@@ -17,7 +17,6 @@
 package nvidia
 
 import (
-	"fmt"
 	"log"
 	"os"
 	"strings"
@@ -65,7 +64,7 @@ func (g *GpuDeviceManager) Devices() []*Device {
 	for i := uint(0); i < n; i++ {
 		d, err := nvml.NewDeviceLite(i)
 		check(err)
-		devs = append(devs, buildDevice(d))
+		devs = append(devs, buildDevice(d, i))
 	}
 
 	return devs
@@ -84,14 +83,12 @@ func (g *GpuDeviceManager) CheckHealth(stop <-chan struct{}, devices []*Device, 
 	checkHealth(stop, devices, unhealthy)
 }
 
-func buildDevice(d *nvml.Device) *Device {
+func buildDevice(d *nvml.Device, devIndex uint) *Device {
 	dev := Device{}
 	dev.ID = d.UUID
 	dev.Health = pluginapi.Healthy
 	dev.Path = d.Path
-
-	_, err := fmt.Sscanf(d.Path, "/dev/nvidia%d", &dev.Index)
-	check(err)
+	dev.Index = devIndex
 
 	if d.CPUAffinity != nil {
 		dev.Topology = &pluginapi.TopologyInfo{

--- a/pkg/plugin/nvidia/utils.go
+++ b/pkg/plugin/nvidia/utils.go
@@ -73,9 +73,7 @@ func GetDevices() ([]*pluginapi.Device, map[uint]string) {
 	for i := uint(0); i < n; i++ {
 		d, err := nvml.NewDevice(i)
 		check(err)
-		var id uint
-		_, err = fmt.Sscanf(d.Path, "/dev/nvidia%d", &id)
-		check(err)
+		id := i
 		deviceByIndex[id] = d.UUID
 		// TODO: Do we assume all cards are of same capacity
 		if GetGPUMemory() == uint(0) {


### PR DESCRIPTION
Signed-off-by: yougjiahe <yongjiahe@tuputech.com>

Warning UnexpectedAdmissionError 79s kubelet Allocate failed due to rpc error: code = Unknown desc = failed to find gpu id, which is unexpected 

If you have use nvidia-smi to hide gpu, index will be change, number of device will be decrease. Such as
```
nvidia-smi drain -p <id> -m 0
```
Or some gpu is damage，it disable by drive. The ids of /dev/nvdiax are not continuous.  Use nvml gpu sequence index replace dev path id more reasonable.