### PR TITLE
feat: support --device-list-strategy=volume-mounts

### DIFF
--- a/cmd/vgpu/main.go
+++ b/cmd/vgpu/main.go
@@ -66,6 +66,7 @@ func init() {
 	rootCmd.Flags().UintVar(&config.DeviceSplitCount, "device-split-count", 2, "the number for NVIDIA device split")
 	rootCmd.Flags().Float64Var(&config.DeviceCoresScaling, "device-cores-scaling", 1.0, "the ratio for NVIDIA device cores scaling")
 	rootCmd.Flags().StringVar(&config.NodeName, "node-name", viper.GetString("node-name"), "node name")
+	rootCmd.Flags().StringVar(&config.DeviceListStrategy, "device-list-strategy", "envvar", "the strategy for passing the device list to the container runtime:\n\t\t[envvar | volume-mounts | cdi-annotations]")
 
 	rootCmd.PersistentFlags().AddGoFlagSet(util.GlobalFlagSet())
 	rootCmd.AddCommand(config.VersionCmd)
@@ -128,7 +129,7 @@ restart:
 
 		// Start the gRPC server for plugin p and connect it with the kubelet.
 		if err := p.Start(); err != nil {
-			//klog.SetOutput(os.Stderr)
+			// klog.SetOutput(os.Stderr)
 			klog.Info("Could not contact Kubelet, retrying. Did you enable the device plugin feature gate?")
 			klog.Info("You can check the prerequisites at: https://github.com/NVIDIA/k8s-device-plugin#prerequisites")
 			klog.Info("You can learn how to set the runtime at: https://github.com/NVIDIA/k8s-device-plugin#quick-start")

--- a/pkg/plugin/vgpu/config/config.go
+++ b/pkg/plugin/vgpu/config/config.go
@@ -22,4 +22,5 @@ var (
 	NodeName           string
 	RuntimeSocketFlag  string
 	DisableCoreLimit   bool
+	DeviceListStrategy string
 )


### PR DESCRIPTION
Add support for pass devices via `volume-mounts`.

https://github.com/NVIDIA/k8s-device-plugin#configuration-option-details

> The DEVICE_LIST_STRATEGY flag allows one to choose which strategy the plugin will use to advertise the list of GPUs allocated to a container. This is traditionally done by setting the NVIDIA_VISIBLE_DEVICES environment variable as described [here](https://github.com/NVIDIA/nvidia-container-runtime#nvidia_visible_devices). This strategy can be selected via the (default) envvar option. Support has been added to the nvidia-container-toolkit to also allow passing the list of devices as a set of volume mounts instead of as an environment variable. This strategy can be selected via the volume-mounts option. Details for the rationale behind this strategy can be found [here](https://docs.google.com/document/d/1uXVF-NWZQXgP1MLb87_kMkQvidpnkNWicdpO2l9g-fw/edit#heading=h.b3ti65rojfy5).

references:

- https://github.com/NVIDIA/k8s-device-plugin/blob/5c4e43d1b84afeb5a0f77492847e9ecbf35aba16/internal/plugin/server.go#L309C1-L312C3


