### PR TITLE
Support core resource limitation in vGPU mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ spec:
       args: ["100000"]
       resources:
         limits:
-          volcano.sh/vgpu-number: 2 # requesting 1 gpu cards
+          volcano.sh/vgpu-number: 2 # requesting 2 gpu cards
           volcano.sh/vgpu-memory: 3000 # each vGPU uses 3G device memory
           volcano.sh/vgpu-cores: 50 # each vGPU uses 50% core  
 EOF

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ $ kubectl create -f volcano-device-plugin.yml
 
 ### Running VGPU Jobs
 
-VGPU can be requested by both set "volcano.sh/vgpu-number" and "volcano.sh/vgpu-memory" in resource.limit
+VGPU can be requested by both set "volcano.sh/vgpu-number" , "volcano.sh/vgpu-cores" and "volcano.sh/vgpu-memory" in resource.limit
 
 ```shell script
 $ cat <<EOF | kubectl apply -f -
@@ -106,7 +106,8 @@ spec:
       resources:
         limits:
           volcano.sh/vgpu-number: 2 # requesting 1 gpu cards
-          volcano.sh/vgpu-memory: 3000
+          volcano.sh/vgpu-memory: 3000 # each vGPU uses 3G device memory
+          volcano.sh/vgpu-cores: 50 # each vGPU uses 50% core  
 EOF
 ```
 ### Running GPU Sharing Jobs (**Will be deprecated in volcano v1.9**)

--- a/examples/vgpu-case01.yml
+++ b/examples/vgpu-case01.yml
@@ -13,4 +13,4 @@ spec:
     resources:
       limits:
         volcano.sh/vgpu-memory: 1024
-        #volcano.sh/vgpu-number: 1
+        volcano.sh/vgpu-number: 1

--- a/examples/vgpu-case02.yml
+++ b/examples/vgpu-case02.yml
@@ -12,5 +12,6 @@ spec:
     args: ["100000"]
     resources:
       limits:
-        volcano.sh/vgpu-number: 1
-        volcano.sh/vgpu-memory: 1024
+        volcano.sh/vgpu-number: 1 #request 1 GPU
+        volcano.sh/vgpu-cores: 50 #each GPU request 50% of compute core resources
+        volcano.sh/vgpu-memory: 10240 #each GPU request 10G device memory

--- a/pkg/plugin/vgpu/plugin.go
+++ b/pkg/plugin/vgpu/plugin.go
@@ -342,6 +342,7 @@ func (m *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *pluginapi.Alloc
 				response.Envs["NVIDIA_VISIBLE_DEVICES"] = dev.UUID
 			}
 		}
+		response.Envs["CUDA_DEVICE_SM_LIMIT"] = fmt.Sprint(devreq[0].Usedcores)
 		response.Envs["CUDA_DEVICE_MEMORY_SHARED_CACHE"] = fmt.Sprintf("/tmp/vgpu/%v.cache", uuid.NewUUID())
 
 		cacheFileHostDirectory := "/tmp/vgpu/containers/" + string(current.UID) + "_" + currentCtr.Name
@@ -371,7 +372,7 @@ func (m *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *pluginapi.Alloc
 		}
 		if !found {
 			response.Mounts = append(response.Mounts, &pluginapi.Mount{ContainerPath: "/etc/ld.so.preload",
-				HostPath: hostHookPath + "/vgpu/ld.so.preload",
+				HostPath: hostHookPath + "/ld.so.preload",
 				ReadOnly: true},
 			)
 		}


### PR DESCRIPTION
User can support core limitation in vGPU mode by specifying "volcano.sh/vgpu-cores"

for example, "volcano.sh/vgpu-cores: 50" means this container can use up to 50% of total compute resources for each GPU mounted

Refer to README.md and examples folder for more examples.
