### PR TITLE
Fix ci failure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v3
       - uses: actions/setup-go@v2
         with:
           go-version: "^1.19.x"
@@ -31,6 +32,6 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v1
 
-      - run: make ubuntu20.04
-      - run: TAG_VERSION="${BRANCH_NAME}" make push-tag
-      - run: make push-latest
+      - run: VERSION="${BRANCH_NAME}" make ubuntu20.04
+      - run: VERSION="${BRANCH_NAME}" make push-short
+      - run: VERSION="${BRANCH_NAME}" make push-latest


### PR DESCRIPTION
`TAG_VERSION` and `make push-tag` was removed by https://github.com/volcano-sh/devices/pull/65
We need to update the CI task as well.

Failure history: https://github.com/volcano-sh/devices/actions/runs/8752334183/job/24019754773
